### PR TITLE
Fix conditional move of jar file

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-tachidesk-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-tachidesk-config/run
@@ -15,4 +15,6 @@ lsiown -R abc:abc \
     /app/suwayomi-server \
     /build
 
-mv /build/Suwayomi-Server.jar /app/suwayomi-server/Suwayomi-Server.jar 
+if [ -f "/build/Suwayomi-Server.jar" ]; then
+    mv -f /build/Suwayomi-Server.jar /app/suwayomi-server/Suwayomi-Server.jar
+fi


### PR DESCRIPTION
This pull request fixes an issue where the jar file was being moved without checking if it exists. The conditional statement ensures that the move operation only occurs if the jar file exists.